### PR TITLE
チェックリストのステータス更新関数の共通化

### DIFF
--- a/src/app/checklists/[id]/page.tsx
+++ b/src/app/checklists/[id]/page.tsx
@@ -103,6 +103,50 @@ const ChecklistDetailPage = () => {
     });
   };
 
+  const handleChecklistStatusUpdate = async (
+    updatedItems: CheckListItem[],
+    checklist: Checklist | null,
+    setChecklist: (checklist: Checklist) => void,
+    token: string,
+    checklistId: number
+  ) => {
+    const allItemsCompleted = updatedItems.every((item) => item.status === "Completed");
+    const someItemsPending = updatedItems.some((item) => item.status === "Pending");
+
+    if (allItemsCompleted && checklist?.status !== "Completed") {
+      const res = await fetch(`/api/checklists/${checklistId}`, {
+        method: "PATCH",
+        headers: {
+          Authorization: token,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ status: "Completed" }),
+      });
+
+      if (!res.ok) throw new Error("チェックリストのステータスの更新に失敗しました");
+
+      const updatedChecklist = await res.json();
+      setChecklist(updatedChecklist);
+      alert("全てのアイテムとチェックリストが完了しました");
+
+    } else if (someItemsPending && checklist?.status === "Completed") {
+      const res = await fetch(`/api/checklists/${checklistId}`, {
+        method: "PATCH",
+        headers: {
+          Authorization: token,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ status: "Pending" }),
+      });
+
+      if (!res.ok) throw new Error("チェックリストのステータスの更新に失敗しました");
+
+      const updatedChecklist = await res.json();
+      setChecklist(updatedChecklist);
+    }
+  };
+
+
   // アイテムのステータスを更新
   const handleItemsStatusChange = async (itemId: number, newStatus: "Pending" | "Completed") => {
     try {

--- a/src/app/checklists/[id]/page.tsx
+++ b/src/app/checklists/[id]/page.tsx
@@ -84,13 +84,10 @@ const ChecklistDetailPage = () => {
     }
   }, [id, token]);
 
-
   // アイテムのステータス更新ロジック
   const updateItemStatusInState = (updatedItem: CheckListItem) => {
     // 全体アイテム更新
-    setItems((prev) =>
-      prev.map((item) => (item.id === updatedItem.id ? updatedItem : item))
-    );
+    setItems((prev) => prev.map((item) => (item.id === updatedItem.id ? updatedItem : item)));
 
     // グループ化されたアイテムの更新
     setGroupedItems((prev) => {
@@ -178,7 +175,6 @@ const ChecklistDetailPage = () => {
 
   // 全てのアイテムのステータスを更新
   const handleCompleteAllItems = async () => {
-
     if (!confirm("全てのアイテムを完了にしますか？")) return;
 
     try {

--- a/src/app/utils/handleChecklistStatusUpdate.ts
+++ b/src/app/utils/handleChecklistStatusUpdate.ts
@@ -1,0 +1,46 @@
+import { CheckListItem, CheckLists } from "@prisma/client";
+
+export const handleChecklistStatusUpdate = async (
+    updatedItems: CheckListItem[],
+    checklist: CheckLists | null,
+    setChecklist: (checklist: CheckLists) => void,
+    token: string,
+    checklistId: number
+  ) => {
+
+console.log("checklistId", typeof checklistId);
+    const allItemsCompleted = updatedItems.every((item) => item.status === "Completed");
+    const someItemsPending = updatedItems.some((item) => item.status === "Pending");
+
+    if (allItemsCompleted && checklist?.status !== "Completed") {
+      const res = await fetch(`/api/checklists/${checklistId}`, {
+        method: "PATCH",
+        headers: {
+          Authorization: token,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ status: "Completed" }),
+      });
+
+      if (!res.ok) throw new Error("チェックリストのステータスの更新に失敗しました");
+
+      const updatedChecklist = await res.json();
+      setChecklist(updatedChecklist);
+      alert("全てのアイテムとチェックリストが完了しました");
+
+    } else if (someItemsPending && checklist?.status === "Completed") {
+      const res = await fetch(`/api/checklists/${checklistId}`, {
+        method: "PATCH",
+        headers: {
+          Authorization: token,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ status: "Pending" }),
+      });
+
+      if (!res.ok) throw new Error("チェックリストのステータスの更新に失敗しました");
+
+      const updatedChecklist = await res.json();
+      setChecklist(updatedChecklist);
+    }
+  };


### PR DESCRIPTION
## 📝 概要
アイテムチェック処理と
アイテムチェック一括処理時に使用していた
チェックリストのステータス更新関数を共通化

## 🔧 変更点
- 共通関数を入れるutilsフォルダを作成

## 💬 備考
