### PR TITLE
Prisma Clientを生成するコマンドの追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "prisma generate"
   },
   "prisma": {
     "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"

--- a/src/app/api/categories/[id]/route.ts
+++ b/src/app/api/categories/[id]/route.ts
@@ -1,6 +1,3 @@
-export const dynamic = "force-dynamic";
-
-
 import {  UpsertCategoryRequestBody } from "@/app/_types/category";
 import { supabase } from "@/lib/supabase";
 import { PrismaClient } from "@prisma/client";


### PR DESCRIPTION
## 📝 概要
開発中にnpx prisma generateを手動で実行していたため、
自動デプロイ時にprismaの生成がうまくできていない状態でデータベースの操作をしていたことで
失敗していた。


VercelはGitリポジトリをクローンし、package.jsonのscripts.buildコマンドを実行することでアプリケーションをビルドする。

